### PR TITLE
Fix formatting of example sequence for N=2 game

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ The game board is a set of eight squares. They will flash in a random order, at 
 Simultaneously, one letter is spoken at each time step. When you recognize that the same letter was spoken exactly N steps ago, you press the   button.
 
 <img src='app/img/example.png?raw=true' width=500px />
-**Example sequence for N=2 game.** The player must remember the state of the game board N steps ago. If you do well, N will increase on the next round. If you don't do so well, N will decrease on the next round (down to N=1). There are 20+N time steps in each round.
+
+**Example sequence for N\=2 game.** The player must remember the state of the game board N steps ago. If you do well, N will increase on the next round. If you don't do so well, N will decrease on the next round (down to N=1). There are 20+N time steps in each round.
 
 ## Credits:
 Based on the work of [1], [2], and others. Audio clips adapted from [5], most of the icons are from [6].


### PR DESCRIPTION
Noticed that GitHub doesn't render **bold** properly for `**Example sequence for N=2 game.** `-- seems to have something to do with =